### PR TITLE
Link milano scala group to the correct meetup

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
         ['Lyon Scala User Group (SLUG)','suglyon', 45.7579555, 4.835121],
         ['Málaga Scala User Group', 'Malaga-Scala', 36.7648321, -4.4241892],
         ['Melbourne Scala User Group', 'Melbourne-Scala-User-Group', -37.8136, 144.9631],
-        ['Milano Scala Group', 'scalamuc', 45.4667, 9.1833],
+        ['Milano Scala Group', 'milano-scala-group', 45.4667, 9.1833],
         ['Munich Scala User Group', 'scalamuc', 48.1333, 11.5667],
         ['Mumbai Scala Functional Programming Meetup', 'Mumbai-Scala-Functional-Programming-Meetup', 18.9750, 72.8258],
         ['New York (ny-scala)', 'ny-scala', 40.7127, -74.0059],


### PR DESCRIPTION
It was pointing to the Munich Scala User Group
