### PR TITLE
Add Lambda Luminaries to scala.space

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
         ['Japan Scala Users Group', 'https://github.com/scalajp', 35.6833, 139.6833],
         ['Kraków Scala User Group', 'Krakow-Scala-User-Group', 50.0614, 19.9383],
         ['Lambda-ES', '%CE%BB-Lambda-ES', 36.4629241, -6.2334788],
+        ['Lambda Luminaries', 'lambda-luminaries', -25.8407139, 28.209476],
         ['Ljubljana Scala User Group', 'Ljubljana-Scala-User-Group', 46.0556, 14.5083],
         ['London Scala Users Group (LSUG)', 'london-scala', 51.5072, -0.1275],
         ['Los Angeles Scala Users Group', 'Los-Angeles-Scala-Users-Group', 34.0500, -118.2500],


### PR DESCRIPTION
Lambda Luminaries is a functional programming group in South Africa.

http://www.meetup.com/lambda-luminaries/
