### PR TITLE
Added http://www.meetup.com/New-York-Scala-University/

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@
         ['Munich Scala User Group', 'scalamuc', 48.1333, 11.5667, true],
         ['Mumbai Scala Functional Programming Meetup', 'Mumbai-Scala-Functional-Programming-Meetup', 18.9750, 72.8258, true],
         ['New York (ny-scala)', 'ny-scala', 40.7127, -74.0059, true],
+        ['New York Scala University', 'New-York-Scala-University', 40.7421, -73.9911, true],
         ['Novosibirsk Scala Enthusiasts', 'ScalaNsk', 55.0167, 82.9333, true],
         ['NoFun', 'no-fun', 29.9500, -90.0667, true],
         ['NZ Scala', 'NZ-Scala', -36.8406, 174.7400, true],


### PR DESCRIPTION
- HBC is hosting a meetup group to teach engineers about Scala in NY. Inaugural class is Tuesday, July 21
