### PR TITLE
Added Perth (Australia) Scala user groups.

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,8 @@
         ['Ottawa Scala Enthusiasts', 'Ottawa-Scala-Enthusiasts', 45.4214, -75.6919, true],
         ['Paris Scala User Group', 'Paris-Scala-User-Group-PSUG', 48.8567, 2.3508, true],
         ['PDXScala', 'PDXScala', 45.5200, -122.6819, true],
+        ['Perth Java and JVM Community', 'Perth-Java-JVM-Community', -31.9516, 115.8573, false],
+        ['Perth Functional Programmers', 'PerthFP', -31.9516, 115.8573, false],
         ['PHASE: Philly Area Scala Enthusiasts', 'scala-phase', 39.9500, -75.1667, true],
         ['Pune Scala Meetup', 'punescala', 18.5203, 73.8567, true],
         ['Rhein Main Scala Enthusiasts', 'Rhein-Main-Scala-Enthusiasts', 50.1167, 8.6833, true],


### PR DESCRIPTION
There are two Scala-related user groups in Perth (Australia): _Java and JVM community_ and _Functional Programmers_.
