### PR TITLE
Lodz Scala Group (part of Lodz JUG)

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
         ['Lambda Luminaries', 'lambda-luminaries', -25.8407139, 28.209476, false],
         ['Ljubljana Scala User Group', 'Ljubljana-Scala-User-Group', 46.0556, 14.5083, true],
         ['London Scala Users Group (LSUG)', 'london-scala', 51.5072, -0.1275, true],
+        ['Lodz JUG', 'lodz-scala',51.7460991,19.4556333,false],
         ['Los Angeles Scala Users Group', 'Los-Angeles-Scala-Users-Group', 34.0500, -118.2500, true],
         ['Lyon Scala User Group (SLUG)','suglyon', 45.7579555, 4.835121, true],
         ['Málaga Scala User Group', 'Malaga-Scala', 36.7648321, -4.4241892, true],


### PR DESCRIPTION
In Lodz we have a common group Lodz JUG which also organize scala workshops and lectures. 
http://www.meetup.com/Java-User-Group-Lodz/#past

http://www.meetup.com/Java-User-Group-Lodz/events/223270143/
http://www.meetup.com/Java-User-Group-Lodz/events/222616038/
http://www.meetup.com/Java-User-Group-Lodz/events/221711414/
http://www.meetup.com/Java-User-Group-Lodz/events/221197835/
http://www.meetup.com/Java-User-Group-Lodz/events/221797554/
