### PR TITLE
Add LambdaHRO

### DIFF
--- a/data/groups.json
+++ b/data/groups.json
@@ -336,6 +336,13 @@
       "justScala": true
     },
     {
+      "name": "LambdaHRO",
+      "url": "https://www.lambdahro.de/",
+      "latitude": 54.0833,
+      "longitude": 12.1333,
+      "justScala": false
+    },
+    {
       "name": "Lambda Luminaries",
       "url": "lambda-luminaries",
       "latitude": -25.8407139,


### PR DESCRIPTION
Add a link to the LambdaHRO group which is located in Rostock (Germany).